### PR TITLE
feat: add jwt secret uri support

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,19 @@ Run the upgrade doctor
 /usr/bin/gitea -c /mnt/volumes/configmaps/gitea.ini doctor \
   recreate-table project system_setting
 ```
+
+## JWT secrets
+
+The container entrypoint reads JWT secrets from files so they can be provided via
+mounted Kubernetes/OpenShift secrets (or Docker secrets) instead of placing
+them directly in `app.ini`.
+
+| Secret | Default file path | Environment override |
+| ------ | ----------------- | -------------------- |
+| Core JWT secret | `/mnt/volumes/secrets/jwt-secret` | `JWT_SECRET_FILE` |
+| LFS JWT secret | `/mnt/volumes/secrets/lfs-jwt-secret` | `LFS_JWT_SECRET_FILE` |
+| OAuth2 JWT secret | `/mnt/volumes/secrets/oauth2-jwt-secret` | `OAUTH2_JWT_SECRET_FILE`
+
+If `GITEA__security__<secret>` variables are already set they take precedence;
+otherwise, the entrypoint exports the values from the files (stripping trailing
+newlines) before launching Gitea.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,7 +13,31 @@ container_version() {
  /usr/bin/gitea --version | awk -F ' ' '{print $3}'
 }
 
+DEFAULT_JWT_SECRET_FILE="/mnt/volumes/secrets/jwt-secret"
+DEFAULT_LFS_JWT_SECRET_FILE="/mnt/volumes/secrets/lfs-jwt-secret"
+DEFAULT_OAUTH2_JWT_SECRET_FILE="/mnt/volumes/secrets/oauth2-jwt-secret"
+
+load_secret_from_file() {
+ VAR_NAME="$1"
+ FILE_PATH="$2"
+ eval "CURRENT_VALUE=\${$VAR_NAME-}"
+ if [ -n "$CURRENT_VALUE" ]; then
+  return
+ fi
+ if [ -f "$FILE_PATH" ]; then
+  SECRET_VALUE=$(tr -d '\r\n' < "$FILE_PATH")
+  export "$VAR_NAME=$SECRET_VALUE"
+ fi
+}
+
+ensure_jwt_secrets() {
+ load_secret_from_file "GITEA__security__JWT_SECRET" "${JWT_SECRET_FILE:-$DEFAULT_JWT_SECRET_FILE}"
+ load_secret_from_file "GITEA__security__LFS_JWT_SECRET" "${LFS_JWT_SECRET_FILE:-$DEFAULT_LFS_JWT_SECRET_FILE}"
+ load_secret_from_file "GITEA__security__OAUTH2_JWT_SECRET" "${OAUTH2_JWT_SECRET_FILE:-$DEFAULT_OAUTH2_JWT_SECRET_FILE}"
+}
+
 container_entrypoint() {
+ ensure_jwt_secrets
  log "-i" "entrypoint" "default"
  /usr/bin/pgrep gitea > /dev/null
  TEST=$?


### PR DESCRIPTION
## Summary
- load core/LFS/OAuth2 JWT secrets from mounted files via entrypoint (defaults under /mnt/volumes/secrets)
- allow overriding the secret file paths with JWT_SECRET_FILE, LFS_JWT_SECRET_FILE, OAUTH2_JWT_SECRET_FILE env vars
- document the secret mechanism in README

## Testing
- shellcheck entrypoint.sh
- podman build (not run: podman CLI unavailable on this host)